### PR TITLE
상단 타이틀 바 뒤로가기 버튼 추가, "활동" 페이지 추가

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,6 +18,6 @@ module.exports = {
             "warn",
             { allowConstantExport: true },
         ],
-        "prettier/prettier": "warning",
+        "prettier/prettier": 1,
     },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "^18.3.1",
         "react-query": "^3.39.3",
         "react-router-dom": "^6.25.1",
+        "skeleton": "^0.1.2",
         "typescript": "^5.5.3"
       },
       "devDependencies": {
@@ -2225,6 +2226,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/coffee-script": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "integrity": "sha512-QjQ1T4BqyHv19k6XSfdhy/QLlIOhywz0ekBUCa9h71zYMJlfDTGan/Z1JXzYkZ6v8R+GhvL/p4FZPbPW8WNXlg==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -2237,6 +2251,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -4052,6 +4074,13 @@
         "node": "*"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4848,6 +4877,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/skeleton": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/skeleton/-/skeleton-0.1.2.tgz",
+      "integrity": "sha512-+7AFCihPnKe93c3qOlWbY3zTMYHe5IuQSA1azTTJ9Z6ILs9GTDx9QCd7zjaGKQtKS8QGQ3dQ+BDXDEhmOUm7vg==",
+      "dependencies": {
+        "coffee-script": "1.3.x",
+        "colors": "0.6.x",
+        "mkdirp": "0.3.x"
+      },
+      "bin": {
+        "skeleton": "bin/skeleton"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^18.3.1",
     "react-query": "^3.39.3",
     "react-router-dom": "^6.25.1",
+    "skeleton": "^0.1.2",
     "typescript": "^5.5.3"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,6 @@ import {
 	Route,
 	RouterProvider,
 } from "react-router-dom";
-import NotFound from "./pages/404/NotFound";
 import PrivateRoute from "./layouts/PrivateRoute";
 import PublicRoute from "./layouts/PublicRoute";
 import DefaultPage from "./pages/default-page/DefaultPage";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,10 +19,7 @@ import Home from "./pages/home/Home";
 import Story from "./pages/story/Story";
 import Statistics from "./pages/statistics/Statistics";
 import Tutorial from "./pages/home/tutorial/TutorialExplain";
-
-interface AutocompletionOption {
-	label: string;
-}
+import Activities from "./pages/activities/Activities";
 
 const router = createBrowserRouter(
 	createRoutesFromElements(
@@ -35,6 +32,7 @@ const router = createBrowserRouter(
 				<Route path="/story" element={<Story />} />
 				<Route path="/statistics" element={<Statistics />} />
 				<Route path="/tutorial" element={<Tutorial />} />
+				<Route path="/activities" element={<Activities />} />
 			</Route>
 			<Route element={<PublicRoute />}>
 				{/* 로그인 없이 접근하는 페이지 정의 */}

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -5,4 +5,8 @@ const requestApi = axios.create({
 	withCredentials: true,
 });
 
+export const getUserTier = async ({ userId }) => {
+	return await requestApi.get(`/tier/user/${userId}`);
+};
+
 export default requestApi;

--- a/src/layouts/Layout/Layout.tsx
+++ b/src/layouts/Layout/Layout.tsx
@@ -1,16 +1,27 @@
 import TitleBar from "./title-bar/TitleBar";
 import NavBar from "./nav-bar/NavBar";
 import { useLocation } from "react-router-dom";
+import { ReactNode } from "react";
 
-export default function Layout({ children }) {
+export default function Layout({ children }: { children: ReactNode }) {
 	const location = useLocation();
 
 	const hideNavBarPaths = ["/login", "/signup", "/tutorial"];
 	const shouldHideNavBar = hideNavBarPaths.includes(location.pathname);
 
+	const showTitleBarPaths: string[] = [
+		"/home",
+		"/story",
+		"/statistics",
+		"/activities",
+	];
+	const hasPreviousButton: boolean = !showTitleBarPaths.includes(
+		location.pathname,
+	);
+
 	return (
 		<>
-			<TitleBar hasPreviousButton={false} />
+			<TitleBar hasPreviousButton={hasPreviousButton} />
 			{children}
 			{!shouldHideNavBar && <NavBar />}
 		</>

--- a/src/layouts/Layout/Layout.tsx
+++ b/src/layouts/Layout/Layout.tsx
@@ -1,11 +1,11 @@
 import TitleBar from "./title-bar/TitleBar";
 import NavBar from "./nav-bar/NavBar";
-import { useLocation } from 'react-router-dom';
+import { useLocation } from "react-router-dom";
 
 export default function Layout({ children }) {
 	const location = useLocation();
 
-	const hideNavBarPaths = ['/login', '/signup', '/tutorial'];
+	const hideNavBarPaths = ["/login", "/signup", "/tutorial"];
 	const shouldHideNavBar = hideNavBarPaths.includes(location.pathname);
 
 	return (

--- a/src/layouts/Layout/title-bar/TitleBar.css
+++ b/src/layouts/Layout/title-bar/TitleBar.css
@@ -13,9 +13,37 @@
 	height: 3.5rem;
 	width: 100%;
 	color: var(--blue);
-	background-color: rgb(253 253, 253);
+	background-color: rgb(253, 253, 253);
 }
 
 .title-bar h2 {
 	margin: 0;
+}
+
+.back-button {
+	border: none; /* 테두리 제거 */
+	background-color: transparent; /* 배경색 투명 */
+	cursor: pointer; /* 커서 모양 변경 */
+	font-size: 24px; /* 아이콘 크기 */
+	color: #333; /* 아이콘 색상 */
+	padding: 8px 12px; /* 패딩 설정 */
+	border-radius: 4px; /* 모서리 둥글게 */
+	transition: color 0.3s; /* 색상 변경 애니메이션 효과 */
+	height:100%;
+}
+
+.back-button::before {
+	content: ""; /* 가상 요소의 내용 */
+	position: absolute; /* 절대 위치 설정 */
+	left: 25px; /* 왼쪽으로부터의 거리 */
+	top: 43%; /* 상위 요소 대비 상단 위치 */
+	transform: translateY(-50%) rotate(45deg); /* 위치 조정 및 회전 */
+	width: 10px; /* 가로 길이 */
+	height: 10px; /* 세로 길이 */
+	border-top: 2px solid #333; /* 상단 테두리 */
+	border-left: 2px solid #333; /* 왼쪽 테두리 */
+	rotate: 270deg;
+}
+.back-button:hover {
+	background-color: #e0e0e0; /* 호버 시 배경색 변경 */
 }

--- a/src/layouts/Layout/title-bar/TitleBar.tsx
+++ b/src/layouts/Layout/title-bar/TitleBar.tsx
@@ -1,19 +1,30 @@
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from "react-router-dom";
 import "./TitleBar.css";
 
-export default function TitleBar({ hasPreviousButton }: { hasPreviousButton: boolean; }) {
-    const navigate = useNavigate();
+export default function TitleBar({
+	hasPreviousButton,
+}: {
+	hasPreviousButton: boolean;
+}) {
+	const navigate = useNavigate();
 
-    const handleTitleClick = () => {
-        navigate('/home');
-    };
+	const handleTitleClick = () => {
+		navigate("/home");
+	};
 
-    return (
-        <div className="title-bar">
-            {hasPreviousButton ? <div>^</div> : undefined}
-            <h2 onClick={handleTitleClick} style={{ cursor: 'pointer' }}>
-                👟RunTale
-            </h2>
-        </div>
-    );
+	return (
+		<div className="title-bar">
+			{hasPreviousButton ? (
+				<div
+					className={"back-button"}
+					onClick={() => {
+						navigate(-1);
+					}}
+				></div>
+			) : undefined}
+			<h2 onClick={handleTitleClick} style={{ cursor: "pointer" }}>
+				👟RunTale
+			</h2>
+		</div>
+	);
 }

--- a/src/pages/activities/Activities.tsx
+++ b/src/pages/activities/Activities.tsx
@@ -1,0 +1,7 @@
+import { Box } from "@mui/material";
+
+function Activities() {
+	return <Box p={1}>Activities</Box>;
+}
+
+export default Activities;

--- a/src/pages/activities/Activities.tsx
+++ b/src/pages/activities/Activities.tsx
@@ -1,7 +1,126 @@
-import { Box } from "@mui/material";
+import { Box, Skeleton } from "@mui/material";
+import { useQuery } from "react-query";
+import { getUserTier } from "../../api/api";
+import { useContext, useState } from "react";
+import AuthContext from "../../context/AuthContext";
+import Title from "../../components/Title";
+
+function EmojiOfTier({ tier }: { tier: string }) {
+	let emoji = <></>;
+	const SIZE = 196;
+	switch (tier) {
+		case "달팽이":
+			emoji = (
+				<picture>
+					<source
+						srcSet="https://fonts.gstatic.com/s/e/notoemoji/latest/1f40c/512.webp"
+						type="image/webp"
+					/>
+					<img
+						src="https://fonts.gstatic.com/s/e/notoemoji/latest/1f40c/512.gif"
+						alt="🐌"
+						width={SIZE}
+						height={SIZE}
+					/>
+				</picture>
+			);
+			break;
+		case "거북이":
+			emoji = (
+				<picture>
+					<source
+						srcSet="https://fonts.gstatic.com/s/e/notoemoji/latest/1f422/512.webp"
+						type="image/webp"
+					/>
+					<img
+						src="https://fonts.gstatic.com/s/e/notoemoji/latest/1f422/512.gif"
+						alt="🐢"
+						width={SIZE}
+						height={SIZE}
+					/>
+				</picture>
+			);
+			break;
+		case "토끼":
+			emoji = (
+				<picture>
+					<source
+						srcSet="https://fonts.gstatic.com/s/e/notoemoji/latest/1f407/512.webp"
+						type="image/webp"
+					/>
+					<img
+						src="https://fonts.gstatic.com/s/e/notoemoji/latest/1f407/512.gif"
+						alt="🐇"
+						width={SIZE}
+						height={SIZE}
+					/>
+				</picture>
+			);
+	}
+	return <Box sx={{ position: "relative", top: "-100px" }}>{emoji}</Box>;
+}
 
 function Activities() {
-	return <Box p={1}>Activities</Box>;
+	const { userId } = useContext(AuthContext);
+	const { isError, isLoading, data } = useQuery({
+		queryKey: "userTier",
+		queryFn: async () => await getUserTier({ userId }),
+	});
+	const [showDetail, setShowDetail] = useState<boolean>(false);
+	/*
+	TODO : USER 정보 실제로 가져와서 프로필 반영
+	 */
+
+	if (isLoading) {
+		return (
+			<Skeleton
+				variant={"rounded"}
+				width={"80%"}
+				height={300}
+				sx={{ m: "100px auto" }}
+			></Skeleton>
+		);
+	}
+	if (isError) {
+		return <span>에러아님</span>;
+	}
+	const { tierName } = data.data.data;
+	return (
+		<Box p={1}>
+			<Box
+				sx={{
+					borderRadius: 2,
+					backgroundColor: "#1890FF",
+					color: "white",
+					height: showDetail ? "500px" : "240px",
+					width: "80%",
+					m: "100px auto",
+				}}
+				onClick={() => {
+					setShowDetail((prev) => !prev);
+				}}
+			>
+				<EmojiOfTier tier={tierName} />
+				<Box sx={{ position: "relative", top: "-80px" }}>
+					<Title level={2}>세종이</Title>
+					<Title level={1}>Lv. 99</Title>
+					{showDetail ? (
+						<span>
+							여어어어어어기이이이이에는
+							<br />
+							디테일
+							<br />
+							같은것드으으으으을
+							<br />
+							이 들어갈
+							<br />
+							예정입니다~~~
+						</span>
+					) : undefined}
+				</Box>
+			</Box>
+		</Box>
+	);
 }
 
 export default Activities;

--- a/src/pages/statistics/Statistics.tsx
+++ b/src/pages/statistics/Statistics.tsx
@@ -1,12 +1,10 @@
 import { Box, Grid } from "@mui/material";
-import TitleBar from "../../layouts/Layout/title-bar/TitleBar";
 import AnimalCrawls from "../../components/AnimalCrawls";
 import Title from "../../components/Title";
 
 export default function Statistics() {
 	return (
 		<Box p={1}>
-			<TitleBar hasPreviousButton={false} />
 			<Title
 				style={{
 					textAlign: "left",
@@ -64,7 +62,7 @@ export default function Statistics() {
 							<p style={{ margin: 0, fontSize: "1.5rem" }}>2</p>
 						</div>
 					</Grid>
-					<Grid xs={4} item>
+					<Grid xs={5} item>
 						<div>
 							<h4 style={{ margin: 0 }}>목표 페이스 달성</h4>
 							<p style={{ margin: 0, fontSize: "1.5rem" }}>2</p>

--- a/src/pages/story/Story.tsx
+++ b/src/pages/story/Story.tsx
@@ -20,7 +20,6 @@ function MockScenarioSquare() {
 export default function Story() {
 	return (
 		<Box p={1}>
-			<TitleBar hasPreviousButton={false} />
 			<Title
 				level={2}
 				style={{

--- a/src/pages/story/Story.tsx
+++ b/src/pages/story/Story.tsx
@@ -1,5 +1,4 @@
 import { Box, List, ListItem, Stack } from "@mui/material";
-import TitleBar from "../../layouts/Layout/title-bar/TitleBar";
 import Title from "../../components/Title";
 import AnimalCrawls from "../../components/AnimalCrawls";
 


### PR DESCRIPTION
## 상단 타이틀 바 뒤로가기 추가

![image](https://github.com/user-attachments/assets/4ee11994-5e8d-40bd-9d9d-96229e479ea4)

- 누르면 전에 있던 페이지로 이동
- `/home, /statistics, /story, /activities` 중 하나에 해당하지 않는 경로인 경우에만 이 "뒤로 가기 버튼"을 띄움

## "활동" 페이지 추가

![image](https://github.com/user-attachments/assets/86efba70-a986-4d45-9ff6-a98bccdb92c5)

- 티어에 따라 움직이는 이모지 프로필 표현
- 컴포넌트를 누르면 상세 정보가 더 나옴 (사진은 누른 상태)
- 유저 정보 fetch는 아직