### PR TITLE
러닝 진행 화면 작업 

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,12 @@
 			src="//dapi.kakao.com/v2/maps/sdk.js?appkey=88b123417622a0f2a18354a1bb7c91f0&libraries=services,clusterer"
 		></script>
 		<!-- 카카오 지도 API 스크립트 -->
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Bitter:ital,wght@1,900&display=swap"
+			rel="stylesheet"
+		/>
 	</head>
 	<body>
 		<div id="root"></div>

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -21,4 +21,17 @@ export const getRunningRecordMonthly = async ({ userId }) => {
 	return await requestApi.get(`/running/user/${userId}/monthly`);
 };
 
+/**
+ *
+ * @param {id?: 러닝ID(처음엔 X), endTime?: 끝난시각(마지막에만), distance: 누적 거리, pace: 누적 페이스} requestBody
+ * @returns
+ */
+export const postRunning = async (requestBody) => {
+	return await requestApi.post(`/running`, requestBody);
+};
+
+export const getRunning = async ({ id }) => {
+	return await requestApi.post(`/running/${id}`);
+};
+
 export default requestApi;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -7,8 +7,7 @@ import React, {
 	useMemo,
 } from "react";
 import { QueryClient } from "react-query";
-import { getCookie } from "../utils/cookie";
-import { useCookies } from "react-cookie";
+import { getUserInfo } from "../api/api";
 
 interface AuthInfo {
 	isAuthenticated: boolean;
@@ -29,8 +28,13 @@ export function AuthProvider({ children }) {
 		userId !== -1,
 	);
 	useMemo(() => ({ isAuthenticated }), [isAuthenticated]);
+	const noLoginPaths = ["/login", "/", "/signup", "/success"];
 
 	useEffect(() => {
+		if (noLoginPaths.includes(location.pathname)) return;
+		getUserInfo({ userId })
+			.then((res) => setIsAuthenticated(true))
+			.catch((error) => setIsAuthenticated(false));
 		/**
 		 * 여기에 "세션 확인" 로직 필요
 		 * 여기에 해야 마운트 시 매번 확인 (새로고침, 새로운 페이지 렌더 등)

--- a/src/pages/running/Running.tsx
+++ b/src/pages/running/Running.tsx
@@ -6,6 +6,7 @@ import { postRunning, getRunning } from "../../api/api";
 import { getDistance, getPace } from "../../utils/running_util";
 import { useNavigate } from "react-router-dom";
 import RunningEnd from "./end/RunningEnd";
+import Status from "./status/Status";
 
 interface PathType {
 	lat: number;
@@ -144,7 +145,7 @@ export default function Running() {
 			{latitude === 0 || longitude === 0 ? undefined : (
 				<Map
 					center={{ lat: latitude, lng: longitude }}
-					style={{ width: "100%", height: "500px" }}
+					style={{ width: "100%", height: "70vh", zIndex: 0 }}
 					level={2}
 					onDragEnd={
 						testMode
@@ -155,6 +156,7 @@ export default function Running() {
 					<Tracker longitude={longitude} latitude={latitude} />
 				</Map>
 			)}
+			<Status distance={distance} startTime={startTime} pace={pace} />
 			<Button
 				variant={testMode ? "contained" : "outlined"}
 				onClick={() => {

--- a/src/pages/running/Running.tsx
+++ b/src/pages/running/Running.tsx
@@ -32,7 +32,6 @@ export default function Running() {
 
 	return (
 		<Box>
-			<h3>Kakao Map.....</h3>
 			{latitude === 0 || longitude === 0 ? undefined : (
 				<Map
 					center={{ lat: latitude, lng: longitude }}

--- a/src/pages/running/Running.tsx
+++ b/src/pages/running/Running.tsx
@@ -1,7 +1,11 @@
 import { Box, Button } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Map, MapMarker, Polyline } from "react-kakao-maps-sdk";
 import Tracker from "./tracker/Tracker";
+import { postRunning, getRunning } from "../../api/api";
+import { getDistance, getPace } from "../../utils/running_util";
+import { useNavigate } from "react-router-dom";
+import RunningEnd from "./end/RunningEnd";
 
 interface PathType {
 	lat: number;
@@ -12,24 +16,129 @@ export default function Running() {
 	const geo: Geolocation = navigator.geolocation;
 	const [latitude, setLatitude] = useState<number>(0);
 	const [longitude, setLongitude] = useState<number>(0);
+	const [prevLatitude, setPrevLatitude] = useState<number>(0);
+	const [prevLongitude, setPrevLongitude] = useState<number>(0);
 	const [testMode, setTestMode] = useState<boolean>(false);
+	const [runningId, setRunningId] = useState<number>();
+	const [startTime, setStartTime] = useState(0);
+	const [distance, setDistance] = useState<number>(0);
+	const [pace, setPace] = useState<number>(0);
+	const [isEnd, setIsEnd] = useState<boolean>(false);
+	const geolocationId = useRef(0);
+	const geoOption = {
+		enableHighAccuracy: true,
+		timeout: 5000,
+		maximumAge: 0,
+	};
 
-	const trackerTest = (map) => {
+	const refreshPosition = () => {
+		geo.getCurrentPosition(
+			(g) => {
+				setLatitude((prev) => {
+					setPrevLatitude(prev);
+					return g.coords.latitude;
+				});
+				setLongitude((prev) => {
+					setPrevLongitude(prev);
+					return g.coords.longitude;
+				});
+			},
+			undefined,
+			geoOption,
+		);
+	};
+
+	const updatePositionManualy = (map) => {
 		const current = map.getCenter();
-		setLatitude(current.getLat());
-		setLongitude(current.getLng());
+		setLatitude((prev) => {
+			setPrevLatitude(prev);
+			return current.getLat();
+		});
+		setLongitude((prev) => {
+			setPrevLongitude(prev);
+			return current.getLng();
+		});
+	};
+
+	const onClickStart = (e) => {
+		postRunning({ distance: distance, pace: pace }).then((res) => {
+			setRunningId(res.data.data.id);
+		});
+		refreshPosition();
+		setStartTime(performance.now());
+	};
+	const onClickEnd = (e) => {
+		postRunning({
+			id: runningId,
+			endTime: new Date(Date.now()),
+			distance: distance,
+			pace: pace,
+		}).then((res) => console.log(res.data.data));
+		setIsEnd(true);
 	};
 
 	/** 마운트 시 위치 이벤트 리스너 등록 */
 	useEffect(() => {
-		const geoId = geo.watchPosition((g) => {
-			setLatitude(g.coords.latitude);
-			setLongitude(g.coords.longitude);
-		});
+		const geoId = geo.watchPosition(
+			(g) => {
+				if (g.coords.accuracy > 100) return;
+				setLatitude((prev) => {
+					setPrevLatitude(prev);
+					return g.coords.latitude;
+				});
+				setLongitude((prev) => {
+					setPrevLongitude(prev);
+					return g.coords.longitude;
+				});
+			},
+			undefined,
+			geoOption,
+		);
+		geolocationId.current = geoId;
 
-		return () => geo.clearWatch(geoId);
+		return () => {
+			if (geolocationId) geo.clearWatch(geoId);
+		};
 	}, []);
 
+	useEffect(() => {
+		if (!latitude || !longitude) return;
+
+		const curDistance = getDistance(
+			prevLatitude,
+			prevLongitude,
+			latitude,
+			longitude,
+		);
+
+		const curPace = getPace(curDistance, performance.now() - startTime);
+
+		postRunning({
+			id: runningId,
+			distance: distance + curDistance,
+			pace: curPace,
+		});
+
+		setDistance((prev) => prev + curDistance);
+		setPace(curPace);
+	}, [latitude, longitude]);
+
+	if (!runningId)
+		return (
+			<Button
+				sx={{ justifyContent: "center" }}
+				variant="contained"
+				onClick={onClickStart}
+			>
+				러닝 시작하기!
+			</Button>
+		);
+	if (isEnd) {
+		return <RunningEnd distance={distance} pace={pace} />;
+	}
+	if (latitude === 0 || longitude === 0) {
+		refreshPosition();
+	}
 	return (
 		<Box>
 			{latitude === 0 || longitude === 0 ? undefined : (
@@ -37,7 +146,11 @@ export default function Running() {
 					center={{ lat: latitude, lng: longitude }}
 					style={{ width: "100%", height: "500px" }}
 					level={2}
-					onDragEnd={testMode ? (map) => trackerTest(map) : undefined}
+					onDragEnd={
+						testMode
+							? (map) => updatePositionManualy(map)
+							: undefined
+					}
 				>
 					<Tracker longitude={longitude} latitude={latitude} />
 				</Map>
@@ -46,9 +159,36 @@ export default function Running() {
 				variant={testMode ? "contained" : "outlined"}
 				onClick={() => {
 					setTestMode((prev) => !prev);
+					if (testMode) {
+						geo.clearWatch(geolocationId.current);
+						geolocationId.current = 0;
+					} else {
+						geolocationId.current = geo.watchPosition((g) => {
+							setLatitude((prev) => {
+								setPrevLatitude(prev);
+								return g.coords.latitude;
+							});
+							setLongitude((prev) => {
+								setPrevLongitude(prev);
+								return g.coords.longitude;
+							});
+						});
+					}
 				}}
 			>
 				TEST {testMode ? "ON" : "OFF"}
+			</Button>
+			<Button
+				variant="outlined"
+				onClick={() => {
+					refreshPosition();
+				}}
+			>
+				위치 새로고침
+			</Button>
+
+			<Button variant={"outlined"} onClick={onClickEnd}>
+				러닝 그만하기
 			</Button>
 		</Box>
 	);

--- a/src/pages/running/end/RunningEnd.tsx
+++ b/src/pages/running/end/RunningEnd.tsx
@@ -1,0 +1,16 @@
+import { getFormattedDistance } from "../../../utils/running_util";
+
+interface RunningResult {
+	distance: number;
+	pace: number;
+}
+
+export default function RunningEnd({ distance, pace }: RunningResult) {
+	const [km, m] = getFormattedDistance(distance);
+	return (
+		<>
+			총 거리 : {`${km}km ${m}m`} <br />
+			페이스 : {pace}
+		</>
+	);
+}

--- a/src/pages/running/end/RunningEnd.tsx
+++ b/src/pages/running/end/RunningEnd.tsx
@@ -6,10 +6,10 @@ interface RunningResult {
 }
 
 export default function RunningEnd({ distance, pace }: RunningResult) {
-	const [km, m] = getFormattedDistance(distance);
+	const km = getFormattedDistance(distance);
 	return (
 		<>
-			총 거리 : {`${km}km ${m}m`} <br />
+			총 거리 : {`${km}km`} <br />
 			페이스 : {pace}
 		</>
 	);

--- a/src/pages/running/status/Status.css
+++ b/src/pages/running/status/Status.css
@@ -1,0 +1,8 @@
+.bitter {
+	font-family: "Bitter", serif;
+	font-optical-sizing: auto;
+	font-weight: 900;
+	font-style: italic;
+	font-size: x-large;
+	margin: 0 3px;
+}

--- a/src/pages/running/status/Status.tsx
+++ b/src/pages/running/status/Status.tsx
@@ -1,0 +1,66 @@
+import { Box, Grid } from "@mui/material";
+import {
+	getFormattedDistance,
+	getFormattedPace,
+	getFormattedTime,
+} from "../../../utils/running_util";
+import { useEffect, useState } from "react";
+import Title from "../../../components/Title";
+import "./Status.css";
+
+interface StatusPropsType {
+	distance: number;
+	startTime: number;
+	pace: number;
+}
+
+export default function Status({ distance, startTime, pace }: StatusPropsType) {
+	const km = getFormattedDistance(distance);
+	const [time, setTime] = useState<number>(startTime);
+	const [minutes, seconds] = getFormattedTime(time);
+	const [paceMinutes, paceSeconds] = getFormattedPace(pace);
+	const TIME_INTERVAL = 1000;
+
+	useEffect(() => {
+		const interval = setInterval((e) => {
+			setTime((prev) => prev + TIME_INTERVAL);
+		}, TIME_INTERVAL);
+
+		return () => {
+			clearInterval(interval);
+		};
+	}, []);
+
+	return (
+		<Box
+			m={1}
+			mt={4}
+			sx={{
+				// display: "flex",
+				// justifyContent: "space-evenly",
+				// alignItems: "center",
+				height: "100px",
+				borderRadius: 3,
+				backgroundColor: "#DCE9F5",
+			}}
+		>
+			<Grid container spacing={2}>
+				<Grid item xs={4}>
+					<span className="bitter">{km}</span>km
+					<Title level={3}>달린 거리</Title>
+				</Grid>
+				<Grid item xs={4}>
+					<span className="bitter">
+						{pace === Infinity ? "-" : paceMinutes}
+					</span>
+					<Title level={3}>평균 페이스</Title>
+				</Grid>
+				<Grid item xs={4}>
+					<span className="bitter">{minutes}</span>분
+					<span className="bitter">{seconds}</span>초
+					<Title level={3}>시간</Title>
+				</Grid>
+			</Grid>
+		</Box>
+	);
+}

--- a/src/pages/story/Story.tsx
+++ b/src/pages/story/Story.tsx
@@ -1,6 +1,7 @@
 import { Box, List, ListItem, Stack } from "@mui/material";
 import Title from "../../components/Title";
 import AnimalCrawls from "../../components/AnimalCrawls";
+import { Navigate, useNavigate } from "react-router-dom";
 
 function MockScenarioSquare() {
 	return (
@@ -17,6 +18,10 @@ function MockScenarioSquare() {
 }
 
 export default function Story() {
+	const navigate = useNavigate();
+	const onClickRunningStart = (e) => {
+		navigate("/running");
+	};
 	return (
 		<Box p={1}>
 			<Title
@@ -49,6 +54,12 @@ export default function Story() {
 					<ListItem sx={{ p: 0.5 }}>
 						<MockScenarioSquare />
 						시나리오 4
+					</ListItem>
+					<ListItem
+						sx={{ p: 2, border: "1px solid gray" }}
+						onClick={onClickRunningStart}
+					>
+						<h2>그냥 달려봐요</h2>
 					</ListItem>
 				</List>
 			</Stack>

--- a/src/utils/running_util.js
+++ b/src/utils/running_util.js
@@ -34,9 +34,21 @@ export function getPace(distance, elapsedTime) {
 export function getFormattedDistance(distance) {
 	const km = Math.trunc(distance);
 	const m = Math.trunc((distance - km) * 1000);
-	return [km, m];
+	return km + m / 1000;
 }
 
 export function getFormattedPace(pace) {
-	return pace;
+	const minutes = Math.trunc(pace);
+	const seconds = Math.trunc((pace - minutes) / 60);
+	return [minutes, seconds];
+}
+
+export function getFormattedTime(elapsedTime) {
+	const minutes = Math.trunc(elapsedTime / 1000 / 60);
+	const seconds = Math.trunc((elapsedTime - minutes * 60000) / 1000);
+	const milliseconds = Math.trunc(
+		elapsedTime - minutes * 60000 - seconds * 1000,
+	);
+
+	return [minutes, seconds, milliseconds];
 }

--- a/src/utils/running_util.js
+++ b/src/utils/running_util.js
@@ -1,0 +1,42 @@
+export function getDistance(prevLat, prevLng, curLat, curLng) {
+	if (!prevLat || !prevLng || !curLat || !curLng) return 0;
+
+	const toRadians = (degrees) => degrees * (Math.PI / 180);
+
+	const R = 6371; // Radius of the Earth in kilometers
+
+	const lat1 = prevLat;
+	const lon1 = prevLng;
+	const lat2 = curLat;
+	const lon2 = curLng;
+
+	const dLat = toRadians(lat2 - lat1);
+	const dLon = toRadians(lon2 - lon1);
+
+	const a =
+		Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+		Math.cos(toRadians(lat1)) *
+			Math.cos(toRadians(lat2)) *
+			Math.sin(dLon / 2) *
+			Math.sin(dLon / 2);
+
+	const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+	return R * c;
+}
+
+export function getPace(distance, elapsedTime) {
+	// elapsedTime in seconds
+	const timeInMinutes = elapsedTime / 60;
+	return timeInMinutes / distance; // pace in minutes per kilometer
+}
+
+export function getFormattedDistance(distance) {
+	const km = Math.trunc(distance);
+	const m = Math.trunc((distance - km) * 1000);
+	return [km, m];
+}
+
+export function getFormattedPace(pace) {
+	return pace;
+}


### PR DESCRIPTION
러닝 화면 작업
- 시작할 때 api 호출, 달리면서 매 위치마다 api 호출, 끝날 때 api 호출 로직 완료
- 지도상에 현재 위치와 지나온 경로 표현
- 달린 거리, 시간, 페이스 등 현재 통계 컴포넌트 추가
- TODO :
  - 페이스 계산이 잘 못 들어갔는지 값이 꽤 크게 나옴.. 로직 수정해야할 듯(귀찮아서 GPT로해서그런듯ㅋㅋ)
  - 페이지 새로고침 시 state값들이 모두 초기화되므로, runningId로 기존에 진행중이었던 러닝 이력을 다시 가져오도록 하는 로직 추가 필요
- 위치 정확도 관련
  - PC웹은 IP위치를 기반으로 하기에 정확도도 떨어지고 방법이 없나봄 ㅜㅜ
  - 반면 모바일 웹은 기기 특성상 GPS 위치에 직접 접근하므로 보통 잘 나오나봄(실험은 안 해봄. 임시 배포 후 지켜봐야 할 듯)
  - 위치 새로고침 버튼을 임시로 만들었으나, 효과없음
  - 정확도 값이 일정치를 초과하면 경로 계산에 쓰지 않으나, PC웹에서는 이 방법도 효과 없는 듯함

러닝 시작 직전, 러닝 완료 직후 화면은 UI작업 중. api호출과 값 저장은 완